### PR TITLE
Moved to error stream

### DIFF
--- a/Invoke-Parallel.Tests.ps1
+++ b/Invoke-Parallel.Tests.ps1
@@ -7,5 +7,11 @@ Describe 'Invoke-Parallel with default parameters' {
         $out.Count | Should Be 11
         $out[5][0] | Should Be 'a'
     }
+
+    It 'should output runspace errors to error stream' {
+        $out = 0 | Invoke-Parallel -ScriptBlock {Write-Error "A Fake Error!"} -ErrorVariable OutError
+        $out.Count | Should Be 0
+        $OutError[0].ToString() | Should Be "A Fake Error!"
+    }
 }
 

--- a/Invoke-Parallel.ps1
+++ b/Invoke-Parallel.ps1
@@ -269,8 +269,9 @@
                                 #set the logging info and move the file to completed
                                 $log.status = "CompletedWithErrors"
                                 Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
-                                Write-Warning "Errors from worker runspace:"
-                                $runspace.powershell.Streams.Error
+                                foreach($ErrorRecord in $runspace.powershell.Streams.Error) {
+                                    Write-Error -ErrorRecord $ErrorRecord
+                                }
                             }
                             else {
                                 


### PR DESCRIPTION
First stab at using pester.... Let me know if you have any preferences on organizing the tests, haven't worked with this before!

Moved from returning Streams.Error directly to looping through this collection and writing to the error stream.

@vors - I swapped out the Write-Warning when errors occur.  I see the value in separating errors within the runspace though, if you prefer that feedback mechanism feel free to swap it back in!