### PR TITLE
Minor changes, test cases

### DIFF
--- a/Invoke-Parallel.Tests.ps1
+++ b/Invoke-Parallel.Tests.ps1
@@ -55,6 +55,23 @@ Describe 'Invoke-Parallel' {
             } | Should Be $null
         }
 
+        It 'should honor time out' {
+            $timeout = $null
+            0 | Invoke-Parallel -RunspaceTimeout 1 -WarningVariable TimeOut {
+                Start-Sleep -Seconds 2
+            }
+            $timeout | Should Match "Runspace timed out at*"
+
+        }
+
+        It 'should pass in a specified variable as $parameter' {
+            $a = 5
+            0 | Invoke-Parallel -Parameter $a {
+                $parameter
+            } | Should Be 5
+
+        }
+
     }
 }
 


### PR DESCRIPTION
A few changes, mostly cleaning up old sloppy code:

* Removed passthru code and comment based help.  This was not a parameter... 
* Changed logic to only AddArgument if $parameter was passed
* Added Warning output if a runspace times out.  Seems more appropriate than solely verbose output