### PR TITLE
Implement $Using: support from @proxb

### DIFF
--- a/Tests/Invoke-Parallel.Tests.ps1
+++ b/Tests/Invoke-Parallel.Tests.ps1
@@ -97,9 +97,7 @@ Describe "Invoke-Parallel PS$PSVersion" {
                     $using:a
                 } | Should Be 4
             }
-
         }
-
     }
 }
 

--- a/Tests/Invoke-Parallel.Tests.ps1
+++ b/Tests/Invoke-Parallel.Tests.ps1
@@ -83,6 +83,23 @@ Describe "Invoke-Parallel PS$PSVersion" {
             } | Should Be 5
         }
 
+        It 'should support $using in PowerShell 3 and later' {
+            $a = 4
+            if($PSVersionTable.PSVersion.Major -eq 2)
+            {
+                0 | Invoke-Parallel @Verbose -ScriptBlock {
+                    $using:a
+                } | Should Throw
+            }
+            elseif($PSVersionTable.PSVersion.Major -gt 2)
+            {
+                0 | Invoke-Parallel @Verbose -ScriptBlock {
+                    $using:a
+                } | Should Be 4
+            }
+
+        }
+
     }
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_commits:
   message: /updated readme.*/
 
 install:
-  - cinst pester
+  - cinst pester -y
 
 build: false
 


### PR DESCRIPTION
This adds support for $Using:Variable syntax (#14) through the AST.  Functionality is limited to PowerShell 3 or later.

Code is nearly verbatim from @proxb, all credit to his work in [PoshRSJob](https://github.com/proxb/PoshRSJob).

Will merge this tonight if there are no concerns!