### PR TITLE
Multiple using statements - Fixes #24

### DIFF
--- a/Tests/Invoke-Parallel.Tests.ps1
+++ b/Tests/Invoke-Parallel.Tests.ps1
@@ -84,18 +84,26 @@ Describe "Invoke-Parallel PS$PSVersion" {
         }
 
         It 'should support $using in PowerShell 3 and later' {
-            $a = 4
             if($PSVersionTable.PSVersion.Major -eq 2)
             {
+                $a = 4
                 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
-                } | Should Throw
+                } | Should Be $Null
             }
             elseif($PSVersionTable.PSVersion.Major -gt 2)
             {
                 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
                 } | Should Be 4
+
+                #Multiple $using statements
+                $x = 1
+                $Output = 0 | Invoke-Parallel @Verbose -ScriptBlock {
+                    $using:x
+                    "$using:x"
+                }
+                $Output.count | Should Be 2
             }
         }
     }

--- a/Tests/Invoke-Parallel.Tests.ps1
+++ b/Tests/Invoke-Parallel.Tests.ps1
@@ -84,9 +84,10 @@ Describe "Invoke-Parallel PS$PSVersion" {
         }
 
         It 'should support $using in PowerShell 3 and later' {
+            $a = 4
+
             if($PSVersionTable.PSVersion.Major -eq 2)
             {
-                $a = 4
                 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
                 } | Should Be $Null
@@ -98,10 +99,9 @@ Describe "Invoke-Parallel PS$PSVersion" {
                 } | Should Be 4
 
                 #Multiple $using statements
-                $x = 1
                 $Output = 0 | Invoke-Parallel @Verbose -ScriptBlock {
-                    $using:x
-                    "$using:x"
+                    $using:a
+                    "$using:a"
                 }
                 $Output.count | Should Be 2
             }


### PR DESCRIPTION
This addresses a bug in the handling of $Using syntax.  Calling the same variable twice would previously error out per issue #24