### PR TITLE
Fixing Import-Module for PS2 due to AppVeyor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/xsbki1rrxo2nh3fy/branch/master?svg=true)](https://ci.appveyor.com/project/RamblingCookieMonster/invoke-parallel/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/e2mfe1vf99maoe64?svg=true)](https://ci.appveyor.com/project/brow1920/invoke-parallel)
 
 Invoke-Parallel
 ==========

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/e2mfe1vf99maoe64?svg=true)](https://ci.appveyor.com/project/brow1920/invoke-parallel)
+[![Build status](https://ci.appveyor.com/api/projects/status/xsbki1rrxo2nh3fy/branch/master?svg=true)](https://ci.appveyor.com/project/RamblingCookieMonster/invoke-parallel/branch/master)
 
 Invoke-Parallel
 ==========

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -28,16 +28,22 @@ param(
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
 
-        $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
-        Write-Host "Pester module is in folder $PesterModule"
-        $pesterPsd1 = Join-Path $PesterModule "\Pester.psd1"
-        Write-host "Pester psd1 file is at:$pesterPsd1"
-        $pesterPsm1 = Join-Path $PesterModule "\Pester.psm1"
-        Write-host "Pester psm1 file is at:$pesterPsm1"
-        Import-Module $pesterPsd1 -Verbose
-        Import-Module $pesterPsm1 -Verbose
 
-
+        if($PSVersionTable.PSVersion.Major -gt 2)
+        {
+            Import-Module Pester
+        }
+        elseif($PSVersionTable.PSVersion.Major -eq 2)
+        {
+            $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
+            Write-Host "Pester module is in folder $PesterModule"
+            $pesterPsd1 = Join-Path $PesterModule "\Pester.psd1"
+            Write-host "Pester psd1 file is at:$pesterPsd1"
+            $pesterPsm1 = Join-Path $PesterModule "\Pester.psm1"
+            Write-host "Pester psm1 file is at:$pesterPsm1"
+            Import-Module $pesterPsd1 -Verbose
+            Import-Module $pesterPsm1 -Verbose
+        }
 
         #$pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path
         #Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -36,13 +36,13 @@ param(
         elseif($PSVersionTable.PSVersion.Major -eq 2)
         {
             $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
-            Write-Host "Pester module is in folder $PesterModule"
+            #Write-Host "Pester module is in folder $PesterModule"
             $pesterPsd1 = Join-Path $PesterModule "\Pester.psd1"
-            Write-host "Pester psd1 file is at:$pesterPsd1"
+            #Write-host "Pester psd1 file is at:$pesterPsd1"
             $pesterPsm1 = Join-Path $PesterModule "\Pester.psm1"
-            Write-host "Pester psm1 file is at:$pesterPsm1"
-            Import-Module $pesterPsd1 -Verbose
-            Import-Module $pesterPsm1 -Verbose
+            #Write-host "Pester psm1 file is at:$pesterPsm1"
+            Import-Module $pesterPsd1
+            Import-Module $pesterPsm1
         }
 
         #$pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -27,9 +27,9 @@ param(
     if($Test)
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
-        refreshenv
-        Get-Module -all
-        import-Module C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1 -Verbose
+        #refreshenv
+        #Get-Module -all
+        import-Module C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3 -Verbose
         #Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -28,10 +28,10 @@ param(
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
 
-        $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | select FullName -ErrorAction SilentlyContinue
+        $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
         Write-Host "Pester module is in folder $PesterModule"
 
-        $pesterModuleTry2 = Get-Module pester | Select Path -ErrorAction SilentlyContinue
+        $pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path
         Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"
 
         Import-Module $pesterModuleTry2 -ErrorAction SilentlyContinue

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,7 +29,7 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         #refreshenv
         #Get-Module -all
-        import-Module C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3 -Verbose
+        import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3' -Verbose
         #Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,7 +29,9 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         #refreshenv
         #Get-Module -all
-        Import-Module "C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\bin" -Verbose
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
+
         Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -28,8 +28,15 @@ param(
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
 
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1'
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1'
+        $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | select FullName -ErrorAction SilentlyContinue
+        Write-Host "Pester module is in folder $PesterModule"
+
+        $pesterModuleTry2 = Get-Module pester | Select Path -ErrorAction SilentlyContinue
+        Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"
+
+        Import-Module $pesterModuleTry2 -ErrorAction SilentlyContinue
+        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' 
+        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1'
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,10 +29,10 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         #refreshenv
         #Get-Module -all
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
+       # Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
+        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
 
-        Import-Module -Name Pester -Verbose
+        #Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -27,7 +27,7 @@ param(
     if($Test)
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
-    
+        refreshenv
         Import-Module Pester
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -28,29 +28,20 @@ param(
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
 
-
+    #If Powershell version 3 or higher, import pester module as usual.
         if($PSVersionTable.PSVersion.Major -gt 2)
         {
             Import-Module Pester
         }
+    #If Powershell version 2, look for the latest version of pester module and import with full file paths.
         elseif($PSVersionTable.PSVersion.Major -eq 2)
         {
             $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
-            #Write-Host "Pester module is in folder $PesterModule"
             $pesterPsd1 = Join-Path $PesterModule "\Pester.psd1"
-            #Write-host "Pester psd1 file is at:$pesterPsd1"
             $pesterPsm1 = Join-Path $PesterModule "\Pester.psm1"
-            #Write-host "Pester psm1 file is at:$pesterPsm1"
             Import-Module $pesterPsd1
             Import-Module $pesterPsm1
         }
-
-        #$pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path
-        #Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"
-
-        #Import-Module $pesterModuleTry2 -ErrorAction SilentlyContinue
-        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' 
-        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1'
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -27,12 +27,9 @@ param(
     if($Test)
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
-        #refreshenv
-        #Get-Module -all
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
-        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
 
-        #Import-Module -Name Pester -Verbose
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1'
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1'
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -28,7 +28,8 @@ param(
     {
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         refreshenv
-        Import-Module Pester
+        Get-Module -all
+        Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,7 +29,8 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         refreshenv
         Get-Module -all
-        Import-Module -Name Pester -Verbose
+        import-Module C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1 -Verbose
+        #Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,8 +29,8 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         #refreshenv
         #Get-Module -all
-       # Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
-        #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' -Verbose
+        Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1' -Verbose
 
         #Import-Module -Name Pester -Verbose
 

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -29,8 +29,8 @@ param(
         "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
         #refreshenv
         #Get-Module -all
-        import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3' -Verbose
-        #Import-Module -Name Pester -Verbose
+        Import-Module "C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\bin" -Verbose
+        Import-Module -Name Pester -Verbose
 
         Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
             Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -30,11 +30,19 @@ param(
 
         $PesterModule = gci "C:\Program Files\WindowsPowerShell\Modules\Pester" | ? { $_.PSIsContainer } | sort Name -desc | select -f 1 | Select -ExpandProperty FullName
         Write-Host "Pester module is in folder $PesterModule"
+        $pesterPsd1 = Join-Path $PesterModule "\Pester.psd1"
+        Write-host "Pester psd1 file is at:$pesterPsd1"
+        $pesterPsm1 = Join-Path $PesterModule "\Pester.psm1"
+        Write-host "Pester psm1 file is at:$pesterPsm1"
+        Import-Module $pesterPsd1 -Verbose
+        Import-Module $pesterPsm1 -Verbose
 
-        $pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path
-        Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"
 
-        Import-Module $pesterModuleTry2 -ErrorAction SilentlyContinue
+
+        #$pesterModuleTry2 = Get-Module pester | Select -ExpandProperty Path
+        #Write-Host "Pester moduletry2 is in folder $pesterModuleTry2"
+
+        #Import-Module $pesterModuleTry2 -ErrorAction SilentlyContinue
         #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psd1' 
         #Import-Module 'C:\Program Files\WindowsPowerShell\Modules\Pester\3.4.3\Pester.psm1'
 


### PR DESCRIPTION
This resolves Issue #42 

Although your code didn't change, it appears that the AppVeyor server may have changed. 

The command "Import-Module Pester" no longer works for PowerShell 2 using AppVeyor service.  

I just ran through your blog post about getting set up with PowerShell / Git / Pester / AppVeyor for CI/CD and was running into errors.  Rather than give up on your post, I decided I would dig in and see if there is anything I could do to help.  The quickest solution I came up with simply checks if you're running PS2 and if so, find the direct path to the pester module and import using the full path.  This option looks for the latest version of the Pester module on the AppVeyor server before importing it, so it should be somewhat future-proof - depending on how the admin for AppVeyor has his server set up.

This is my first PR using public GitHub - but I figured this would help.  If you don't accept the PR, could you at least make a note on your blog post or somewhere that your current code/method no longer works and maybe an option to fix it?

Thanks!