### PR TITLE
following best practices to not use aliases

### DIFF
--- a/Invoke-Parallel/Invoke-Parallel.ps1
+++ b/Invoke-Parallel/Invoke-Parallel.ps1
@@ -231,7 +231,7 @@ function Invoke-Parallel {
                 $UserSnapins = @( Get-PSSnapin | Select-Object -ExpandProperty Name | Where-Object {$StandardUserEnv.Snapins -notcontains $_ } )
             }
             if($ImportFunctions) {
-                $UserFunctions = @( Get-ChildItem function:\ | Where { $StandardUserEnv.Functions -notcontains $_.Name } )
+                $UserFunctions = @( Get-ChildItem function:\ | Where-Object { $StandardUserEnv.Functions -notcontains $_.Name } )
             }
         }
 


### PR DESCRIPTION
Just a cosmetic fix. You used "Where" instead of "Where-Object" once. 

Thanks for this great Cmdlet!