### PR TITLE
Addresses Runspacepool Variable Scope Creep

### DIFF
--- a/Invoke-Parallel/Invoke-Parallel.ps1
+++ b/Invoke-Parallel/Invoke-Parallel.ps1
@@ -212,7 +212,7 @@ function Invoke-Parallel {
                     Snapins     = $Snapins
                     Functions   = $Functions
                 }
-            }).invoke()[0]
+            },$true).invoke()[0]
 
             if ($ImportVariables) {
                 #Exclude common parameters, bound parameters, and automatic variables


### PR DESCRIPTION
https://learn-powershell.net/2018/01/28/dealing-with-runspacepool-variable-scope-creep-in-powershell/

the link explains more thoroughly, but essentially sometimes values will carry over from parallel invocations

this change sets UseLocalScope to $True