### PR TITLE
Consistent formatting and PSScriptAnalyzer rules

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,0 +1,42 @@
+@{
+    Rules = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $true  #Differs From Default PSScriptAnalyzer Codeformatting and Stroustrup
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $True
+            Kind                = 'spaces'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable          = $True
+            CheckInnerBrace = $true
+            CheckOpenBrace  = $true
+            CheckOpenParen  = $true
+            CheckOperator   = $False
+            CheckPipe       = $true
+            CheckSeparator  = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+        PSUseCorrectCasing         = @{
+            Enable = $true
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    // Generic Settings
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "editor.autoIndent": true,
+    "editor.trimAutoWhitespace": true,
+    "files.encoding": "utf8",
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": false,
+    "editor.formatOnType": true,
+
+    // PowerShell Generic Setting
+    "powershell.codeFormatting.preset": "Custom",
+    "powershell.scriptAnalysis.settingsPath": ".vscode\\analyzersettings.psd1",
+    "powershell.scriptAnalysis.enable": true,
+    "powershell.startAutomatically": true,
+
+    // PowerShell Code Formating
+    "powershell.codeFormatting.openBraceOnSameLine": true,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.newLineAfterOpenBrace": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.whitespaceAroundPipe": true,
+    "powershell.codeFormatting.whitespaceInsideBrace": false,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.alignPropertyValuePairs": true,
+    "powershell.codeFormatting.useCorrectCasing": true,
+}

--- a/Invoke-Parallel/Invoke-Parallel.ps1
+++ b/Invoke-Parallel/Invoke-Parallel.ps1
@@ -148,17 +148,17 @@ function Invoke-Parallel {
     .LINK
         https://github.com/RamblingCookieMonster/Invoke-Parallel
     #>
-    [cmdletbinding(DefaultParameterSetName='ScriptBlock')]
+    [cmdletbinding(DefaultParameterSetName = 'ScriptBlock')]
     Param (
-        [Parameter(Mandatory=$false,position=0,ParameterSetName='ScriptBlock')]
+        [Parameter(Mandatory = $false, position = 0, ParameterSetName = 'ScriptBlock')]
         [System.Management.Automation.ScriptBlock]$ScriptBlock,
 
-        [Parameter(Mandatory=$false,ParameterSetName='ScriptFile')]
-        [ValidateScript({Test-Path $_ -pathtype leaf})]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ScriptFile')]
+        [ValidateScript( {Test-Path $_ -pathtype leaf})]
         $ScriptFile,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [Alias('CN','__Server','IPAddress','Server','ComputerName')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias('CN', '__Server', 'IPAddress', 'Server', 'ComputerName')]
         [PSObject]$InputObject,
 
         [PSObject]$Parameter,
@@ -173,18 +173,18 @@ function Invoke-Parallel {
         [switch]$NoCloseOnTimeout = $false,
         [int]$MaxQueue,
 
-        [validatescript({Test-Path (Split-Path $_ -parent)})]
+        [validatescript( {Test-Path (Split-Path $_ -parent)})]
         [switch] $AppendLog = $false,
         [string]$LogFile,
 
         [switch] $Quiet = $false
     )
-    begin {
+    Begin {
         #No max queue specified?  Estimate one.
         #We use the script scope to resolve an odd PowerShell 2 issue where MaxQueue isn't seen later in the function
-        if( -not $PSBoundParameters.ContainsKey('MaxQueue') ) {
-            if($RunspaceTimeout -ne 0){ $script:MaxQueue = $Throttle }
-            else{ $script:MaxQueue = $Throttle * 3 }
+        if ( -not $PSBoundParameters.ContainsKey('MaxQueue') ) {
+            if ($RunspaceTimeout -ne 0) { $script:MaxQueue = $Throttle }
+            else { $script:MaxQueue = $Throttle * 3 }
         }
         else {
             $script:MaxQueue = $MaxQueue
@@ -194,29 +194,29 @@ function Invoke-Parallel {
 
         #If they want to import variables or modules, create a clean runspace, get loaded items, use those to exclude items
         if ($ImportVariables -or $ImportModules -or $ImportFunctions) {
-            $StandardUserEnv = [powershell]::Create().addscript({
+            $StandardUserEnv = [powershell]::Create().addscript( {
 
-                #Get modules, snapins, functions in this clean runspace
-                $Modules = Get-Module | Select-Object -ExpandProperty Name
-                $Snapins = Get-PSSnapin | Select-Object -ExpandProperty Name
-                $Functions = Get-ChildItem function:\ | Select-Object -ExpandProperty Name
+                    #Get modules, snapins, functions in this clean runspace
+                    $Modules = Get-Module | Select-Object -ExpandProperty Name
+                    $Snapins = Get-PSSnapin | Select-Object -ExpandProperty Name
+                    $Functions = Get-ChildItem function:\ | Select-Object -ExpandProperty Name
 
-                #Get variables in this clean runspace
-                #Called last to get vars like $? into session
-                $Variables = Get-Variable | Select-Object -ExpandProperty Name
+                    #Get variables in this clean runspace
+                    #Called last to get vars like $? into session
+                    $Variables = Get-Variable | Select-Object -ExpandProperty Name
 
-                #Return a hashtable where we can access each.
-                @{
-                    Variables   = $Variables
-                    Modules     = $Modules
-                    Snapins     = $Snapins
-                    Functions   = $Functions
-                }
-            },$true).invoke()[0]
+                    #Return a hashtable where we can access each.
+                    @{
+                        Variables = $Variables
+                        Modules   = $Modules
+                        Snapins   = $Snapins
+                        Functions = $Functions
+                    }
+                }, $true).invoke()[0]
 
             if ($ImportVariables) {
                 #Exclude common parameters, bound parameters, and automatic variables
-                Function _temp {[cmdletbinding(SupportsShouldProcess=$True)] param() }
+                Function _temp {[cmdletbinding(SupportsShouldProcess = $True)] param() }
                 $VariablesToExclude = @( (Get-Command _temp | Select-Object -ExpandProperty parameters).Keys + $PSBoundParameters.Keys + $StandardUserEnv.Variables )
                 Write-Verbose "Excluding variables $( ($VariablesToExclude | Sort-Object ) -join ", ")"
 
@@ -231,311 +231,311 @@ function Invoke-Parallel {
                 $UserModules = @( Get-Module | Where-Object {$StandardUserEnv.Modules -notcontains $_.Name -and (Test-Path $_.Path -ErrorAction SilentlyContinue)} | Select-Object -ExpandProperty Path )
                 $UserSnapins = @( Get-PSSnapin | Select-Object -ExpandProperty Name | Where-Object {$StandardUserEnv.Snapins -notcontains $_ } )
             }
-            if($ImportFunctions) {
+            if ($ImportFunctions) {
                 $UserFunctions = @( Get-ChildItem function:\ | Where-Object { $StandardUserEnv.Functions -notcontains $_.Name } )
             }
         }
 
         #region functions
-            Function Get-RunspaceData {
-                [cmdletbinding()]
-                param( [switch]$Wait )
-                #loop through runspaces
-                #if $wait is specified, keep looping until all complete
-                Do {
-                    #set more to false for tracking completion
-                    $more = $false
+        Function Get-RunspaceData {
+            [cmdletbinding()]
+            param( [switch]$Wait )
+            #loop through runspaces
+            #if $wait is specified, keep looping until all complete
+            Do {
+                #set more to false for tracking completion
+                $more = $false
 
-                    #Progress bar if we have inputobject count (bound parameter)
-                    if (-not $Quiet) {
-                        Write-Progress -Id $ProgressId -Activity "Running Query" -Status "Starting threads"`
-                            -CurrentOperation "$startedCount threads defined - $totalCount input objects - $script:completedCount input objects processed"`
-                            -PercentComplete $( Try { $script:completedCount / $totalCount * 100 } Catch {0} )
-                    }
+                #Progress bar if we have inputobject count (bound parameter)
+                if (-not $Quiet) {
+                    Write-Progress -Id $ProgressId -Activity "Running Query" -Status "Starting threads"`
+                        -CurrentOperation "$startedCount threads defined - $totalCount input objects - $script:completedCount input objects processed"`
+                        -PercentComplete $( Try { $script:completedCount / $totalCount * 100 } Catch {0} )
+                }
 
-                    #run through each runspace.
-                    Foreach($runspace in $runspaces) {
+                #run through each runspace.
+                foreach ($runspace in $runspaces) {
 
-                        #get the duration - inaccurate
-                        $currentdate = Get-Date
-                        $runtime = $currentdate - $runspace.startTime
-                        $runMin = [math]::Round( $runtime.totalminutes ,2 )
+                    #get the duration - inaccurate
+                    $currentdate = Get-Date
+                    $runtime = $currentdate - $runspace.startTime
+                    $runMin = [math]::Round( $runtime.totalminutes , 2 )
 
-                        #set up log object
-                        $log = "" | Select-Object Date, Action, Runtime, Status, Details
-                        $log.Action = "Removing:'$($runspace.object)'"
-                        $log.Date = $currentdate
-                        $log.Runtime = "$runMin minutes"
+                    #set up log object
+                    $log = "" | Select-Object Date, Action, Runtime, Status, Details
+                    $log.Action = "Removing:'$($runspace.object)'"
+                    $log.Date = $currentdate
+                    $log.Runtime = "$runMin minutes"
 
-                        #If runspace completed, end invoke, dispose, recycle, counter++
-                        If ($runspace.Runspace.isCompleted) {
+                    #If runspace completed, end invoke, dispose, recycle, counter++
+                    If ($runspace.Runspace.isCompleted) {
 
-                            $script:completedCount++
+                        $script:completedCount++
 
-                            #check if there were errors
-                            if($runspace.powershell.Streams.Error.Count -gt 0) {
-                                #set the logging info and move the file to completed
-                                $log.status = "CompletedWithErrors"
-                                Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
-                                foreach($ErrorRecord in $runspace.powershell.Streams.Error) {
-                                    Write-Error -ErrorRecord $ErrorRecord
-                                }
-                            }
-                            else {
-                                #add logging details and cleanup
-                                $log.status = "Completed"
-                                Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
-                            }
-
-                            #everything is logged, clean up the runspace
-                            $runspace.powershell.EndInvoke($runspace.Runspace)
-                            $runspace.powershell.dispose()
-                            $runspace.Runspace = $null
-                            $runspace.powershell = $null
-                        }
-                        #If runtime exceeds max, dispose the runspace
-                        ElseIf ( $runspaceTimeout -ne 0 -and $runtime.totalseconds -gt $runspaceTimeout) {
-                            $script:completedCount++
-                            $timedOutTasks = $true
-
-                            #add logging details and cleanup
-                            $log.status = "TimedOut"
+                        #check if there were errors
+                        if ($runspace.powershell.Streams.Error.Count -gt 0) {
+                            #set the logging info and move the file to completed
+                            $log.status = "CompletedWithErrors"
                             Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
-                            Write-Error "Runspace timed out at $($runtime.totalseconds) seconds for the object:`n$($runspace.object | out-string)"
-
-                            #Depending on how it hangs, we could still get stuck here as dispose calls a synchronous method on the powershell instance
-                            if (!$noCloseOnTimeout) { $runspace.powershell.dispose() }
-                            $runspace.Runspace = $null
-                            $runspace.powershell = $null
-                            $completedCount++
-                        }
-
-                        #If runspace isn't null set more to true
-                        ElseIf ($runspace.Runspace -ne $null ) {
-                            $log = $null
-                            $more = $true
-                        }
-
-                        #log the results if a log file was indicated
-                        if($logFile -and $log) {
-                            ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1] | out-file $LogFile -append
-                        }
-                    }
-
-                    #Clean out unused runspace jobs
-                    $temphash = $runspaces.clone()
-                    $temphash | Where-Object { $_.runspace -eq $Null } | ForEach-Object {
-                        $Runspaces.remove($_)
-                    }
-
-                    #sleep for a bit if we will loop again
-                    if($PSBoundParameters['Wait']){ Start-Sleep -milliseconds $SleepTimer }
-
-                #Loop again only if -wait parameter and there are more runspaces to process
-                } while ($more -and $PSBoundParameters['Wait'])
-
-            #End of runspace function
-            }
-        #endregion functions
-
-        #region Init
-
-            if($PSCmdlet.ParameterSetName -eq 'ScriptFile') {
-                $ScriptBlock = [scriptblock]::Create( $(Get-Content $ScriptFile | out-string) )
-            }
-            elseif($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {
-                #Start building parameter names for the param block
-                [string[]]$ParamsToAdd = '$_'
-                if( $PSBoundParameters.ContainsKey('Parameter') ) {
-                    $ParamsToAdd += '$Parameter'
-                }
-
-                $UsingVariableData = $Null
-
-                # This code enables $Using support through the AST.
-                # This is entirely from  Boe Prox, and his https://github.com/proxb/PoshRSJob module; all credit to Boe!
-
-                if($PSVersionTable.PSVersion.Major -gt 2) {
-                    #Extract using references
-                    $UsingVariables = $ScriptBlock.ast.FindAll({$args[0] -is [System.Management.Automation.Language.UsingExpressionAst]},$True)
-
-                    If ($UsingVariables) {
-                        $List = New-Object 'System.Collections.Generic.List`1[System.Management.Automation.Language.VariableExpressionAst]'
-                        ForEach ($Ast in $UsingVariables) {
-                            [void]$list.Add($Ast.SubExpression)
-                        }
-
-                        $UsingVar = $UsingVariables | Group-Object -Property SubExpression | ForEach-Object {$_.Group | Select-Object -First 1}
-
-                        #Extract the name, value, and create replacements for each
-                        $UsingVariableData = ForEach ($Var in $UsingVar) {
-                            try {
-                                $Value = Get-Variable -Name $Var.SubExpression.VariablePath.UserPath -ErrorAction Stop
-                                [pscustomobject]@{
-                                    Name = $Var.SubExpression.Extent.Text
-                                    Value = $Value.Value
-                                    NewName = ('$__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
-                                    NewVarName = ('__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
-                                }
-                            }
-                            catch {
-                                Write-Error "$($Var.SubExpression.Extent.Text) is not a valid Using: variable!"
+                            foreach ($ErrorRecord in $runspace.powershell.Streams.Error) {
+                                Write-Error -ErrorRecord $ErrorRecord
                             }
                         }
-                        $ParamsToAdd += $UsingVariableData | Select-Object -ExpandProperty NewName -Unique
+                        else {
+                            #add logging details and cleanup
+                            $log.status = "Completed"
+                            Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
+                        }
 
-                        $NewParams = $UsingVariableData.NewName -join ', '
-                        $Tuple = [Tuple]::Create($list, $NewParams)
-                        $bindingFlags = [Reflection.BindingFlags]"Default,NonPublic,Instance"
-                        $GetWithInputHandlingForInvokeCommandImpl = ($ScriptBlock.ast.gettype().GetMethod('GetWithInputHandlingForInvokeCommandImpl',$bindingFlags))
+                        #everything is logged, clean up the runspace
+                        $runspace.powershell.EndInvoke($runspace.Runspace)
+                        $runspace.powershell.dispose()
+                        $runspace.Runspace = $null
+                        $runspace.powershell = $null
+                    }
+                    #If runtime exceeds max, dispose the runspace
+                    ElseIf ( $runspaceTimeout -ne 0 -and $runtime.totalseconds -gt $runspaceTimeout) {
+                        $script:completedCount++
+                        $timedOutTasks = $true
 
-                        $StringScriptBlock = $GetWithInputHandlingForInvokeCommandImpl.Invoke($ScriptBlock.ast,@($Tuple))
+                        #add logging details and cleanup
+                        $log.status = "TimedOut"
+                        Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
+                        Write-Error "Runspace timed out at $($runtime.totalseconds) seconds for the object:`n$($runspace.object | Out-String)"
 
-                        $ScriptBlock = [scriptblock]::Create($StringScriptBlock)
+                        #Depending on how it hangs, we could still get stuck here as dispose calls a synchronous method on the powershell instance
+                        if (!$noCloseOnTimeout) { $runspace.powershell.dispose() }
+                        $runspace.Runspace = $null
+                        $runspace.powershell = $null
+                        $completedCount++
+                    }
 
-                        Write-Verbose $StringScriptBlock
+                    #If runspace isn't null set more to true
+                    ElseIf ($runspace.Runspace -ne $null ) {
+                        $log = $null
+                        $more = $true
+                    }
+
+                    #log the results if a log file was indicated
+                    if ($logFile -and $log) {
+                        ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1] | Out-File $LogFile -append
                     }
                 }
 
-                $ScriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock("param($($ParamsToAdd -Join ", "))`r`n" + $Scriptblock.ToString())
-            }
-            else {
-                Throw "Must provide ScriptBlock or ScriptFile"; Break
-            }
-
-            Write-Debug "`$ScriptBlock: $($ScriptBlock | Out-String)"
-            Write-Verbose "Creating runspace pool and session states"
-
-            #If specified, add variables and modules/snapins to session state
-            $sessionstate = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
-            if($ImportVariables -and $UserVariables.count -gt 0) {
-                foreach($Variable in $UserVariables) {
-                    $sessionstate.Variables.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList $Variable.Name, $Variable.Value, $null) )
+                #Clean out unused runspace jobs
+                $temphash = $runspaces.clone()
+                $temphash | Where-Object { $_.runspace -eq $Null } | ForEach-Object {
+                    $Runspaces.remove($_)
                 }
-            }
-            if ($ImportModules) {
-                if($UserModules.count -gt 0) {
-                    foreach($ModulePath in $UserModules) {
-                        $sessionstate.ImportPSModule($ModulePath)
-                    }
-                }
-                if($UserSnapins.count -gt 0) {
-                    foreach($PSSnapin in $UserSnapins) {
-                        [void]$sessionstate.ImportPSSnapIn($PSSnapin, [ref]$null)
-                    }
-                }
-            }
-            if($ImportFunctions -and $UserFunctions.count -gt 0) {
-                foreach ($FunctionDef in $UserFunctions) {
-                    $sessionstate.Commands.Add((New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $FunctionDef.Name,$FunctionDef.ScriptBlock))
-                }
-            }
 
-            #Create runspace pool
-            $runspacepool = [runspacefactory]::CreateRunspacePool(1, $Throttle, $sessionstate, $Host)
-            $runspacepool.Open()
+            #sleep for a bit if we will loop again
+            if ($PSBoundParameters['Wait']) { Start-Sleep -milliseconds $SleepTimer }
 
-            Write-Verbose "Creating empty collection to hold runspace jobs"
-            $Script:runspaces = New-Object System.Collections.ArrayList
+            #Loop again only if -wait parameter and there are more runspaces to process
+        } while ($more -and $PSBoundParameters['Wait'])
 
-            #If inputObject is bound get a total count and set bound to true
-            $bound = $PSBoundParameters.keys -contains "InputObject"
-            if(-not $bound) {
-                [System.Collections.ArrayList]$allObjects = @()
-            }
-
-            #Set up log file if specified
-            if( $LogFile -and (-not (Test-Path $LogFile) -or $AppendLog -eq $false)){
-                New-Item -ItemType file -Path $logFile -Force | Out-Null
-                ("" | Select-Object -Property Date, Action, Runtime, Status, Details | ConvertTo-Csv -NoTypeInformation -Delimiter ";")[0] | Out-File $LogFile
-            }
-
-            #write initial log entry
-            $log = "" | Select-Object -Property Date, Action, Runtime, Status, Details
-                $log.Date = Get-Date
-                $log.Action = "Batch processing started"
-                $log.Runtime = $null
-                $log.Status = "Started"
-                $log.Details = $null
-                if($logFile) {
-                    ($log | convertto-csv -Delimiter ";" -NoTypeInformation)[1] | Out-File $LogFile -Append
-                }
-            $timedOutTasks = $false
-        #endregion INIT
+        #End of runspace function
     }
-    process {
+    #endregion functions
+
+    #region Init
+
+    if ($PSCmdlet.ParameterSetName -eq 'ScriptFile') {
+        $ScriptBlock = [scriptblock]::Create( $(Get-Content $ScriptFile | Out-String) )
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {
+        #Start building parameter names for the param block
+        [string[]]$ParamsToAdd = '$_'
+        if ( $PSBoundParameters.ContainsKey('Parameter') ) {
+            $ParamsToAdd += '$Parameter'
+        }
+
+        $UsingVariableData = $Null
+
+        # This code enables $Using support through the AST.
+        # This is entirely from  Boe Prox, and his https://github.com/proxb/PoshRSJob module; all credit to Boe!
+
+        if ($PSVersionTable.PSVersion.Major -gt 2) {
+            #Extract using references
+            $UsingVariables = $ScriptBlock.ast.FindAll( {$args[0] -is [System.Management.Automation.Language.UsingExpressionAst]}, $True)
+
+            If ($UsingVariables) {
+                $List = New-Object 'System.Collections.Generic.List`1[System.Management.Automation.Language.VariableExpressionAst]'
+                foreach ($Ast in $UsingVariables) {
+                    [void]$list.Add($Ast.SubExpression)
+                }
+
+                $UsingVar = $UsingVariables | Group-Object -Property SubExpression | ForEach-Object {$_.Group | Select-Object -First 1}
+
+                #Extract the name, value, and create replacements for each
+                $UsingVariableData = foreach ($Var in $UsingVar) {
+                    try {
+                        $Value = Get-Variable -Name $Var.SubExpression.VariablePath.UserPath -ErrorAction Stop
+                        [pscustomobject]@{
+                            Name       = $Var.SubExpression.Extent.Text
+                            Value      = $Value.Value
+                            NewName    = ('$__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
+                            NewVarName = ('__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
+                        }
+                    }
+                    catch {
+                        Write-Error "$($Var.SubExpression.Extent.Text) is not a valid Using: variable!"
+                    }
+                }
+                $ParamsToAdd += $UsingVariableData | Select-Object -ExpandProperty NewName -Unique
+
+                $NewParams = $UsingVariableData.NewName -join ', '
+                $Tuple = [Tuple]::Create($list, $NewParams)
+                $bindingFlags = [Reflection.BindingFlags]"Default,NonPublic,Instance"
+                $GetWithInputHandlingForInvokeCommandImpl = ($ScriptBlock.ast.gettype().GetMethod('GetWithInputHandlingForInvokeCommandImpl', $bindingFlags))
+
+                $StringScriptBlock = $GetWithInputHandlingForInvokeCommandImpl.Invoke($ScriptBlock.ast, @($Tuple))
+
+                $ScriptBlock = [scriptblock]::Create($StringScriptBlock)
+
+                Write-Verbose $StringScriptBlock
+            }
+        }
+
+        $ScriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock("param($($ParamsToAdd -Join ", "))`r`n" + $Scriptblock.ToString())
+    }
+    else {
+        Throw "Must provide ScriptBlock or ScriptFile"; Break
+    }
+
+    Write-Debug "`$ScriptBlock: $($ScriptBlock | Out-String)"
+    Write-Verbose "Creating runspace pool and session states"
+
+    #If specified, add variables and modules/snapins to session state
+    $sessionstate = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+    if ($ImportVariables -and $UserVariables.count -gt 0) {
+        foreach ($Variable in $UserVariables) {
+            $sessionstate.Variables.Add((New-Object -TypeName System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList $Variable.Name, $Variable.Value, $null) )
+        }
+    }
+    if ($ImportModules) {
+        if ($UserModules.count -gt 0) {
+            foreach ($ModulePath in $UserModules) {
+                $sessionstate.ImportPSModule($ModulePath)
+            }
+        }
+        if ($UserSnapins.count -gt 0) {
+            foreach ($PSSnapin in $UserSnapins) {
+                [void]$sessionstate.ImportPSSnapIn($PSSnapin, [ref]$null)
+            }
+        }
+    }
+    if ($ImportFunctions -and $UserFunctions.count -gt 0) {
+        foreach ($FunctionDef in $UserFunctions) {
+            $sessionstate.Commands.Add((New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $FunctionDef.Name, $FunctionDef.ScriptBlock))
+        }
+    }
+
+    #Create runspace pool
+    $runspacepool = [runspacefactory]::CreateRunspacePool(1, $Throttle, $sessionstate, $Host)
+    $runspacepool.Open()
+
+    Write-Verbose "Creating empty collection to hold runspace jobs"
+    $Script:runspaces = New-Object System.Collections.ArrayList
+
+    #If inputObject is bound get a total count and set bound to true
+    $bound = $PSBoundParameters.keys -contains "InputObject"
+    if (-not $bound) {
+        [System.Collections.ArrayList]$allObjects = @()
+    }
+
+    #Set up log file if specified
+    if ( $LogFile -and (-not (Test-Path $LogFile) -or $AppendLog -eq $false)) {
+        New-Item -ItemType file -Path $logFile -Force | Out-Null
+        ("" | Select-Object -Property Date, Action, Runtime, Status, Details | ConvertTo-Csv -NoTypeInformation -Delimiter ";")[0] | Out-File $LogFile
+    }
+
+    #write initial log entry
+    $log = "" | Select-Object -Property Date, Action, Runtime, Status, Details
+    $log.Date = Get-Date
+    $log.Action = "Batch processing started"
+    $log.Runtime = $null
+    $log.Status = "Started"
+    $log.Details = $null
+    if ($logFile) {
+        ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1] | Out-File $LogFile -Append
+    }
+    $timedOutTasks = $false
+    #endregion INIT
+    }
+    Process {
         #add piped objects to all objects or set all objects to bound input object parameter
-        if($bound) {
+        if ($bound) {
             $allObjects = $InputObject
         }
         else {
             [void]$allObjects.add( $InputObject )
         }
     }
-    end {
+    End {
         #Use Try/Finally to catch Ctrl+C and clean up.
         try {
             #counts for progress
             $totalCount = $allObjects.count
             $script:completedCount = 0
             $startedCount = 0
-            foreach($object in $allObjects) {
+            foreach ($object in $allObjects) {
                 #region add scripts to runspace pool
-                    #Create the powershell instance, set verbose if needed, supply the scriptblock and parameters
-                    $powershell = [powershell]::Create()
+                #Create the powershell instance, set verbose if needed, supply the scriptblock and parameters
+                $powershell = [powershell]::Create()
 
-                    if ($VerbosePreference -eq 'Continue') {
-                        [void]$PowerShell.AddScript({$VerbosePreference = 'Continue'})
+                if ($VerbosePreference -eq 'Continue') {
+                    [void]$PowerShell.AddScript( {$VerbosePreference = 'Continue'})
+                }
+
+                [void]$PowerShell.AddScript($ScriptBlock).AddArgument($object)
+
+                if ($parameter) {
+                    [void]$PowerShell.AddArgument($parameter)
+                }
+
+                # $Using support from Boe Prox
+                if ($UsingVariableData) {
+                    foreach ($UsingVariable in $UsingVariableData) {
+                        Write-Verbose "Adding $($UsingVariable.Name) with value: $($UsingVariable.Value)"
+                        [void]$PowerShell.AddArgument($UsingVariable.Value)
                     }
+                }
 
-                    [void]$PowerShell.AddScript($ScriptBlock).AddArgument($object)
+                #Add the runspace into the powershell instance
+                $powershell.RunspacePool = $runspacepool
 
-                    if ($parameter) {
-                        [void]$PowerShell.AddArgument($parameter)
+                #Create a temporary collection for each runspace
+                $temp = "" | Select-Object PowerShell, StartTime, object, Runspace
+                $temp.PowerShell = $powershell
+                $temp.StartTime = Get-Date
+                $temp.object = $object
+
+                #Save the handle output when calling BeginInvoke() that will be used later to end the runspace
+                $temp.Runspace = $powershell.BeginInvoke()
+                $startedCount++
+
+                #Add the temp tracking info to $runspaces collection
+                Write-Verbose ( "Adding {0} to collection at {1}" -f $temp.object, $temp.starttime.tostring() )
+                $runspaces.Add($temp) | Out-Null
+
+                #loop through existing runspaces one time
+                Get-RunspaceData
+
+                #If we have more running than max queue (used to control timeout accuracy)
+                #Script scope resolves odd PowerShell 2 issue
+                $firstRun = $true
+                while ($runspaces.count -ge $Script:MaxQueue) {
+                    #give verbose output
+                    if ($firstRun) {
+                        Write-Verbose "$($runspaces.count) items running - exceeded $Script:MaxQueue limit."
                     }
+                    $firstRun = $false
 
-                    # $Using support from Boe Prox
-                    if ($UsingVariableData) {
-                        Foreach($UsingVariable in $UsingVariableData) {
-                            Write-Verbose "Adding $($UsingVariable.Name) with value: $($UsingVariable.Value)"
-                            [void]$PowerShell.AddArgument($UsingVariable.Value)
-                        }
-                    }
-
-                    #Add the runspace into the powershell instance
-                    $powershell.RunspacePool = $runspacepool
-
-                    #Create a temporary collection for each runspace
-                    $temp = "" | Select-Object PowerShell, StartTime, object, Runspace
-                    $temp.PowerShell = $powershell
-                    $temp.StartTime = Get-Date
-                    $temp.object = $object
-
-                    #Save the handle output when calling BeginInvoke() that will be used later to end the runspace
-                    $temp.Runspace = $powershell.BeginInvoke()
-                    $startedCount++
-
-                    #Add the temp tracking info to $runspaces collection
-                    Write-Verbose ( "Adding {0} to collection at {1}" -f $temp.object, $temp.starttime.tostring() )
-                    $runspaces.Add($temp) | Out-Null
-
-                    #loop through existing runspaces one time
+                    #run get-runspace data and sleep for a short while
                     Get-RunspaceData
-
-                    #If we have more running than max queue (used to control timeout accuracy)
-                    #Script scope resolves odd PowerShell 2 issue
-                    $firstRun = $true
-                    while ($runspaces.count -ge $Script:MaxQueue) {
-                        #give verbose output
-                        if($firstRun) {
-                            Write-Verbose "$($runspaces.count) items running - exceeded $Script:MaxQueue limit."
-                        }
-                        $firstRun = $false
-
-                        #run get-runspace data and sleep for a short while
-                        Get-RunspaceData
-                        Start-Sleep -Milliseconds $sleepTimer
-                    }
+                    Start-Sleep -Milliseconds $sleepTimer
+                }
                 #endregion add scripts to runspace pool
             }
             Write-Verbose ( "Finish processing the remaining runspace jobs: {0}" -f ( @($runspaces | Where-Object {$_.Runspace -ne $Null}).Count) )

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This function will take in a script or scriptblock, and run it against specified
 
     $Path = 'C:\temp\'
 
-    'Server1', 'Server2' | Invoke-Parallel {
+    'Server1', 'Server2' | Invoke-Parallel -ScriptBlock {
 
         #Create a log file for this server, use the root $Path
-        $ThisPath = Join-Path $Using:Path "$_.log"
+        $ThisPath = Join-Path -Path $Using:Path -ChildPath "$_.log"
         "Doing something with $_" | Out-File -FilePath $ThisPath -Force
 
     }
@@ -39,13 +39,13 @@ This function will take in a script or scriptblock, and run it against specified
 # Import modules found in the current session
 
     #From https://psremoteregistry.codeplex.com/releases/view/65928
-    Import-Module PSRemoteRegistry
+    Import-Module -Name PSRemoteRegistry
 
     $ServerList | Invoke-Parallel -ImportModules -ScriptBlock {
 
         $Key = 'Software\Microsoft\Windows\CurrentVersion\Policies\System'
         Get-RegValue -ComputerName $_ -Hive LocalMachine -Key $Key |
-            Select ComputerName, Value, Data
+            Select-Object -Property ComputerName, Value, Data
 
     }
 
@@ -64,7 +64,7 @@ This function will take in a script or scriptblock, and run it against specified
 
     $ServerList | Invoke-Parallel -RunspaceTimeout 10 -NoCloseOnTimeout -ScriptBlock {
 
-            Get-WmiObject -Class Win32_OperatingSystem -ComputerName $_ | select -Property PSComputerName, Caption, Version
+            Get-WmiObject -Class Win32_OperatingSystem -ComputerName $_ | Select-Object -Property PSComputerName, Caption, Version
 
     }
 ```

--- a/Tests/Invoke-Parallel.Tests.ps1
+++ b/Tests/Invoke-Parallel.Tests.ps1
@@ -1,43 +1,41 @@
 #handle PS2
-if(-not $PSScriptRoot)
-{
+if (-not $PSScriptRoot) {
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$Verbose = @{}
-if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
-{
-    $Verbose.add("Verbose",$True)
+$Verbose = @{ }
+if ($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master") {
+    $Verbose.add("Verbose", $True)
 }
 
 $PSVersion = $PSVersionTable.PSVersion.Major
 Import-Module $PSScriptRoot\..\Invoke-Parallel\Invoke-Parallel.ps1 -Force
 
 Describe "Invoke-Parallel PS$PSVersion" {
-    
-    Context 'Strict mode' { 
+
+    Context 'Strict mode' {
 
         Set-StrictMode -Version latest
 
         It 'should out string' {
-            $out = (0..10) | Invoke-Parallel @Verbose -ScriptBlock { "a$_" } 
-            $out.Count | Should Be 11
-            $out[5][0] | Should Be 'a'
+            $out = (0..10) | Invoke-Parallel @Verbose -ScriptBlock { "a$_" }
+            $out.Count | Should -Be 11
+            $out[5][0] | Should -Be 'a'
         }
 
         It 'should output runspace errors to error stream' {
             $out = 0 | Invoke-Parallel @Verbose -ErrorVariable OutError -ErrorAction SilentlyContinue -ScriptBlock {
                 Write-Error "A Fake Error!"
             }
-            $out | Should Be $null
-            $OutError[0].ToString() | Should Be "A Fake Error!"
+            $out | Should -Be $null
+            $OutError[0].ToString() | Should -Be "A Fake Error!"
         }
 
         It 'should import variables with one letter name' {
             $a = "Hello"
             0 | Invoke-Parallel @Verbose -ImportVariables -ScriptBlock {
                 $a
-            } | Should Be "Hello"
+            } | Should -Be "Hello"
         }
 
         It 'should import all variables' {
@@ -45,7 +43,7 @@ Describe "Invoke-Parallel PS$PSVersion" {
             $longvar = "World!"
             0 | Invoke-Parallel @Verbose -ImportVariables -ScriptBlock {
                 "$a $longvar"
-            } | Should Be "Hello World!"
+            } | Should -Be "Hello World!"
         }
 
         It 'should not import variables when not specified' {
@@ -53,19 +51,19 @@ Describe "Invoke-Parallel PS$PSVersion" {
             $longvar = "World!"
             0 | Invoke-Parallel @Verbose -ScriptBlock {
                 "$a $longvar"
-            } | Should Be " "
+            } | Should -Be " "
         }
 
         It 'should import modules' {
             0 | Invoke-Parallel @Verbose -ImportModules -ScriptBlock {
-                Get-Module Pester
-            } | Should not Be $null
+                Get-Module -Name Pester
+            } | Should -Not -Be $null
         }
 
         It 'should not import modules when not specified' {
             0 | Invoke-Parallel @Verbose -ScriptBlock {
-                Get-Module Pester
-            } | Should Be $null
+                Get-Module -Name Pester
+            } | Should -Be $null
         }
 
         It 'should honor time out' {
@@ -73,39 +71,36 @@ Describe "Invoke-Parallel PS$PSVersion" {
             0 | Invoke-Parallel @Verbose -RunspaceTimeout 1 -ErrorVariable TimeOut -ScriptBlock {
                 Start-Sleep -Seconds 3
             } -ErrorAction SilentlyContinue
-            $timeout[0].ToString() | Should Match "Runspace timed out at*"
+            $timeout[0].ToString() | Should -Match "Runspace timed out at*"
         }
 
         It 'should pass in a specified variable as $parameter' {
             $a = 5
             0 | Invoke-Parallel @Verbose -Parameter $a -ScriptBlock {
                 $parameter
-            } | Should Be 5
+            } | Should -Be 5
         }
 
         It 'should support $using in PowerShell 3 and later' {
             $a = 4
 
-            if($PSVersionTable.PSVersion.Major -eq 2)
-            {
+            if ($PSVersionTable.PSVersion.Major -eq 2) {
                 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
-                } | Should Be $Null
+                } | Should -Be $Null
             }
-            elseif($PSVersionTable.PSVersion.Major -gt 2)
-            {
+            elseif ($PSVersionTable.PSVersion.Major -gt 2) {
                 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
-                } | Should Be 4
+                } | Should -Be 4
 
                 #Multiple $using statements
                 $Output = 0 | Invoke-Parallel @Verbose -ScriptBlock {
                     $using:a
                     "$using:a"
                 }
-                $Output.count | Should Be 2
+                $Output.count | Should -Be 2
             }
         }
     }
 }
-

--- a/Tests/appveyor.pester.ps1
+++ b/Tests/appveyor.pester.ps1
@@ -3,77 +3,71 @@
 # We serialize XML results and pull them in appveyor.yml
 
 #If Finalize is specified, we collect XML output, upload tests, and indicate build errors
-param(
+param (
     [switch]$Finalize,
     [switch]$Test,
     [string]$ProjectRoot = $ENV:APPVEYOR_BUILD_FOLDER
 )
 
 #Initialize some variables, move to the project root
-    $Timestamp = Get-date -uformat "%Y%m%d-%H%M%S"
-    $PSVersion = $PSVersionTable.PSVersion.Major
-    $TestFile = "TestResults_PS$PSVersion`_$TimeStamp.xml"
+$Timestamp = Get-Date -uformat "%Y%m%d-%H%M%S"
+$PSVersion = $PSVersionTable.PSVersion.Major
+$TestFile = "TestResults_PS$PSVersion`_$TimeStamp.xml"
 
-    $Address = "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)"
-    Set-Location $ProjectRoot
+$Address = "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)"
+Set-Location -Path $ProjectRoot
 
-    $Verbose = @{}
-    if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
-    {
-        $Verbose.add("Verbose",$True)
-    }
-   
+$Verbose = @{ }
+if ($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master") {
+    $Verbose.add("Verbose", $True)
+}
+
 #Run a test with the current version of PowerShell, upload results
-    if($Test)
-    {
-        "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
-    
-        Import-Module Pester
+if ($Test) {
+    "`n`tSTATUS: Testing with PowerShell $PSVersion`n"
 
-        Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
-            Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"
-        
-        If($env:APPVEYOR_JOB_ID)
-        {
-            (New-Object 'System.Net.WebClient').UploadFile( $Address, "$ProjectRoot\$TestFile" )
-        }
+    Import-Module -Name Pester
+
+    Invoke-Pester @Verbose -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
+        Export-Clixml -Path "$ProjectRoot\PesterResults_PS$PSVersion`_$Timestamp.xml"
+
+    If ($env:APPVEYOR_JOB_ID) {
+        (New-Object -TypeName 'System.Net.WebClient').UploadFile( $Address, "$ProjectRoot\$TestFile" )
     }
+}
 
 #If finalize is specified, display errors and fail build if we ran into any
-    If($Finalize)
-    {
-        #Show status...
-            $AllFiles = Get-ChildItem -Path $ProjectRoot\PesterResults*.xml | Select -ExpandProperty FullName
-            "`n`tSTATUS: Finalizing results`n"
-            "COLLATING FILES:`n$($AllFiles | Out-String)"
+If ($Finalize) {
+    #Show status...
+    $AllFiles = Get-ChildItem -Path $ProjectRoot\PesterResults*.xml | Select-Object -ExpandProperty FullName
+    "`n`tSTATUS: Finalizing results`n"
+    "COLLATING FILES:`n$($AllFiles | Out-String)"
 
-        #What failed?
-            $Results = @( Get-ChildItem -Path "$ProjectRoot\PesterResults_PS*.xml" | Import-Clixml )
-            
-            $FailedCount = $Results |
-                Select -ExpandProperty FailedCount |
-                Measure-Object -Sum |
-                Select -ExpandProperty Sum
-    
-            if ($FailedCount -gt 0) {
+    #What failed?
+    $Results = @( Get-ChildItem -Path "$ProjectRoot\PesterResults_PS*.xml" | Import-Clixml )
 
-                $FailedItems = $Results |
-                    Select -ExpandProperty TestResult |
-                    Where {$_.Passed -notlike $True}
+    $FailedCount = $Results |
+        Select-Object -ExpandProperty FailedCount |
+        Measure-Object -Sum |
+        Select-Object -ExpandProperty Sum
 
-                "FAILED TESTS SUMMARY:`n"
-                $FailedItems | ForEach-Object {
-                    $Item = $_
-                    [pscustomobject]@{
-                        Describe = $Item.Describe
-                        Context = $Item.Context
-                        Name = "It $($Item.Name)"
-                        Result = $Item.Result
-                    }
-                } |
-                    Sort Describe, Context, Name, Result |
-                    Format-List
+    if ($FailedCount -gt 0) {
+        $FailedItems = $Results |
+            Select-Object -ExpandProperty TestResult |
+            Where-Object -FilterScript { $_.Passed -notlike $True }
 
-                throw "$FailedCount tests failed."
+        "FAILED TESTS SUMMARY:`n"
+        $FailedItems | ForEach-Object {
+            $Item = $_
+            [PSCustomObject]@{
+                Describe = $Item.Describe
+                Context  = $Item.Context
+                Name     = "It $($Item.Name)"
+                Result   = $Item.Result
             }
+        } |
+        Sort-Object -Property Describe, Context, Name, Result |
+        Format-List
+        throw "$FailedCount tests failed."
     }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
-﻿Install-Module PSDepend -Force
-Invoke-PSDepend -Force -verbose
+﻿Install-Module -Name PSDepend -Force
+Invoke-PSDepend -Force -Verbose
 
 # For PS2, after installing with PS5.
-Move-Item C:\temp\pester\*\* -Destination C:\temp\pester -force
+Move-Item -Path C:\temp\pester\*\* -Destination C:\temp\pester -Force

--- a/requirements.depend.psd1
+++ b/requirements.depend.psd1
@@ -3,15 +3,15 @@
         Target = 'C:\Temp'
     }
 
-    Psake = @{
+    Psake           = @{
         Parameters = @{
-                Force = $True
-                Import = $True
+            Force  = $True
+            Import = $True
         }
         # Addes target (C:\temp) to psmodulepath
-        AddToPath = $True
+        AddToPath  = $True
     }
-    PSDeploy = 'latest'
-    Pester = 'latest'
-    BuildHelpers = 'latest'
+    PSDeploy        = 'latest'
+    Pester          = 'latest'
+    BuildHelpers    = 'latest'
 }


### PR DESCRIPTION
### Consistent formatting and PSScriptAnalyzer rules for vscode

- Added .vscode folder with PSScriptAnalyzer formatting rules that where mostly inline with existing formatting. This will help contributers on an consistent formatting. 
  - Note [PSScriptAnalyzer](https://www.powershellgallery.com/packages/PSScriptAnalyzer/) module with version 1.18.1 or higher needed and [Visual Studio Code](https://code.visualstudio.com/download) with the [PowerShell Extention](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
- Changed formatting where it was not consistent.
  - replaced some tab's with 4 spaces
  - same spaces after 'if' and 'foreach' statements
  - Some Casing Corrections like out-file --> Out-File on line 321
- Changed '| Out-Null' to '$Null = ' For performance improvements
- Updates Functions Synopsis and Readme.md with same guidelines changes
- Updated Pester Test With Pester Module Version 4 changes. 
- Positional Param completion
- Replaced Aliases with Cmdlet names, like 'select' to 'Select-Object'

Hope this Helps @vors 
Thanks for the Great Work I love the Module and use it a lot!